### PR TITLE
fix: case sensitivity detection

### DIFF
--- a/jargon-extractor.sh
+++ b/jargon-extractor.sh
@@ -126,24 +126,24 @@ fi
 
 echo "Computing known and ignored words volumes..."
 
-grep -w -f "$known_words_file" "$candidate_file.tmp" > "$known_volume_file.tmp"
+grep -i -w -f "$known_words_file" "$candidate_file.tmp" > "$known_volume_file.tmp"
 echo "# This file contains known words with their counts" >"$known_volume_file"
 cat "$known_volume_file.tmp" >>"$known_volume_file"
 rm "$known_volume_file.tmp"
 
-grep -w -f "$ignored_words_file" "$candidate_file.tmp" >"$ignored_volume_file.tmp"
+grep -i -w -f "$ignored_words_file" "$candidate_file.tmp" >"$ignored_volume_file.tmp"
 echo "# This file contains ignored words with their counts" >"$ignored_volume_file"
 cat "$ignored_volume_file.tmp" >>"$ignored_volume_file"
 rm "$ignored_volume_file.tmp"
 
 echo "Removing words that are in the known.txt file..."
-grep -v -w -f "$known_words_file" "$candidate_file.tmp" >"$cleaned_candidate_file.tmp"
+grep -i -v -w -f "$known_words_file" "$candidate_file.tmp" >"$cleaned_candidate_file.tmp"
 mv "$cleaned_candidate_file.tmp" "$cleaned_candidate_file"
 
 wc -l "$cleaned_candidate_file" | awk '{printf "%\047.0f candidate remains\n", $1}'
 
 echo "Removing words that are in the ignore.txt file..."
-grep -v -w -f "$ignored_words_file" "$cleaned_candidate_file" >"$cleaned_candidate_file.tmp"
+grep -i -v -w -f "$ignored_words_file" "$cleaned_candidate_file" >"$cleaned_candidate_file.tmp"
 echo "# This file contains candidate words with their counts, excluding known and ignored words" >"$cleaned_candidate_file"
 cat "$cleaned_candidate_file.tmp" >>"$cleaned_candidate_file"
 rm "$cleaned_candidate_file.tmp" "$candidate_file.tmp"


### PR DESCRIPTION
known and ignore files can contain words with
different cases that the one being extracted.

Before

```
candidate_words.txt: 5,930
ignored_words.txt: 1,344
known_words.txt: 568
```

After

```
candidate_words.txt: 5,854
ignored_words.txt: 1,424
known_words.txt: 583
```

Here are examples of words that were wrongly present in candidate_words.txt until now

```
youtube-dl Youtube-DL YoutubeDL
dbus D-Bus DBus
camelcase CamelCase
(...)
```

Most of them are related to the changes that introduced the hyphen as a separator.
